### PR TITLE
Add IndexingOnANonIndexedSeq rule to Linter

### DIFF
--- a/src/main/scala/LinterPlugin.scala
+++ b/src/main/scala/LinterPlugin.scala
@@ -256,6 +256,7 @@ final class LinterPlugin(val global: Global) extends Plugin {
       val SeqLikeClass: Symbol = rootMirror.getClassByName(newTermName("scala.collection.SeqLike"))
       val SeqLikeContains: Symbol = SeqLikeClass.info.member(newTermName("contains"))
       val SeqLikeApply: Symbol = SeqLikeClass.info.member(newTermName("apply"))
+      val IndexedSeqLikeClass: Symbol = rootMirror.getClassByName(newTermName("scala.collection.IndexedSeqLike"))
       val MapFactoryClass = rootMirror.getClassByName(newTermName("scala.collection.generic.MapFactory"))
       val TraversableFactoryClass: Symbol = rootMirror.getClassByName(newTermName("scala.collection.generic.TraversableFactory"))
       val TraversableOnceClass: Symbol = rootMirror.getClassByName(newTermName("scala.collection.TraversableOnce"))
@@ -1943,6 +1944,12 @@ final class LinterPlugin(val global: Global) extends Plugin {
             && (col equalsStructure col1) =>
 
             warn(tree, UseLastNotApply(identOrCol(col)))
+
+          case Apply(Select(seq, _apply), List(index))
+            if methodImplements(tree.symbol, SeqLikeApply)
+            && !isLiteral(index)
+            && !seq.tpe.baseClasses.exists(_.tpe =:= IndexedSeqLikeClass.tpe) =>
+            warn(tree, IndexingOnANonIndexedSeq)
 
           case If(cond, thenp, elsep) if {//Microcosm
 

--- a/src/main/scala/Warning.scala
+++ b/src/main/scala/Warning.scala
@@ -45,6 +45,7 @@ final object Warning {
     IdenticalIfElseCondition,
     IdenticalStatements,
     IndexingWithNegativeNumber,
+    IndexingOnANonIndexedSeq,
     InefficientUseOfListSize("", "", ""),
     IntDivisionAssignedToFloat,
     InvalidParamToRandomNextInt,
@@ -228,6 +229,8 @@ case object IdenticalStatements extends
   Warning("You're doing the exact same thing twice or more.")
 case object IndexingWithNegativeNumber extends
   Warning("Using a negative index for a collection.")
+case object IndexingOnANonIndexedSeq extends
+    Warning("Indexing on a non-IndexedSeq may cause performance problems.")
 case object OptionOfOption extends
   Warning("Why would you need an Option of an Option?")
 case class UndesirableTypeInference(inferredType: String) extends

--- a/src/test/scala/WarningTest.scala
+++ b/src/test/scala/WarningTest.scala
@@ -23,7 +23,7 @@ class WarningTest extends MustThrownMatchers {
   @Test
   def allIncludesAll(): Unit = {
     //TODO: could do it with reflection
-    val knownCount = 123
+    val knownCount = 124
     val count: Int = Warning.All.distinct.map {
       case AssigningOptionToNull => 1
       case AvoidOptionCollectionSize => 1
@@ -48,6 +48,7 @@ class WarningTest extends MustThrownMatchers {
       case IdenticalIfElseCondition => 1
       case IdenticalStatements => 1
       case IndexingWithNegativeNumber => 1
+      case IndexingOnANonIndexedSeq => 1
       case InefficientUseOfListSize(_, _, _) => 1
       case IntDivisionAssignedToFloat => 1
       case InvalidParamToRandomNextInt => 1


### PR DESCRIPTION
Inspired by https://twitter.com/jshrsn/status/865677863646658560, this patch adds a new `IndexingOnANonIndexedSeq` rule which raises a warning when we see code which indexes on a `Seq` which isn't known to be an `IndexedSeq` subtype. The goal here is to make it easier to prevent cases where someone writes an `O(n^2)` loop by accident.

I'm opening this PR against my own fork rather than upstream because this is still an early draft which needs self-review and testing (plus I don't have time now to get it ready for full upstream standards, such as README documentation and examples, etc.; plus it might not be as generally applicable / useful outside of Spark's needs).

This rule should have prevented the following Spark bugs:

- https://github.com/apache/spark/pull/18005
- https://github.com/apache/spark/pull/8178
- https://github.com/apache/spark/pull/15221

For comparision, here is the same rule implemented in `scapegoat`: https://github.com/JoshRosen/scapegoat/pull/1